### PR TITLE
implement updateValue method & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ It rejects an `AwsSecretsManagerError` in case an error occurs (network error, n
 
 **Cache:** The values are cached for 1 day. After that, it will be fetched again from AWS. This reduces API calls and therefore costs significantly. You can clear the cache manually anytime by calling `clearFromCache()`
 
+#### `async updateValue(secretString: string): object`
+
+Modifies the value of a secret, encoded it on base64. The new value will be cached with the new VersionId returned
+
+It rejects an `AwsSecretsManagerError` in case an error occurs (network error, encoding error, etc).
+
 #### `setVersionId(): this`
 
 Sets the version ID to be handled.
@@ -59,6 +65,9 @@ const secretHandler = AwsSecretsManager.secret('my-secret-name-or-arn');
 
 // Get the value with VersionStage of AWSCURRENT
 const value = await secretHandler.getValue();
+
+// Update the value of the secret
+const newValue = await secretHandler.updateValue('new-secret-string');
 
 // Get an specific VersionStage
 const previousValue  = await secretHandler.setVersionStage('AWSPREVIOUS');

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ It rejects an `AwsSecretsManagerError` in case an error occurs (network error, n
 
 #### `async updateValue(newSecret: object): object`
 
-Modifies the value of a secret, encoded it on base64. 
+Modifies the value of a secret
 
-Saves the secret as String in SecretString property. 
+Saves the secret value in string or binary format depending on how it is currently stored
 
-The new value will be cached with the VersionId and VersionStage settled.
+The new value will be cached with the VersionId settled.
 
 It rejects an `AwsSecretsManagerError` in case an error occurs (network error, encoding error, etc).
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ It rejects an `AwsSecretsManagerError` in case an error occurs (network error, n
 
 **Cache:** The values are cached for 1 day. After that, it will be fetched again from AWS. This reduces API calls and therefore costs significantly. You can clear the cache manually anytime by calling `clearFromCache()`
 
-#### `async updateValue(secretString: string): object`
+#### `async updateValue(newSecret: object): object`
 
-Modifies the value of a secret, encoded it on base64. The new value will be cached with the new VersionId returned
+Modifies the value of a secret, encoded it on base64. 
+
+Saves the secret as String in SecretString property. 
+
+The new value will be cached with the VersionId and VersionStage settled.
 
 It rejects an `AwsSecretsManagerError` in case an error occurs (network error, encoding error, etc).
 
@@ -67,7 +71,11 @@ const secretHandler = AwsSecretsManager.secret('my-secret-name-or-arn');
 const value = await secretHandler.getValue();
 
 // Update the value of the secret
-const newValue = await secretHandler.updateValue('new-secret-string');
+const newValue = await secretHandler.updateValue({
+	privateKey: 'new-private-key',
+	apiSecret: 'api-secret',
+	keyPairId: 'key-pair-id'
+});
 
 // Get an specific VersionStage
 const previousValue  = await secretHandler.setVersionStage('AWSPREVIOUS');

--- a/lib/secret-handler.js
+++ b/lib/secret-handler.js
@@ -116,6 +116,41 @@ module.exports = class SecretHandler {
 	}
 
 	/**
+	 * Update the value of the secret.
+	 *
+	 * @param {String} secretString The new value of the secret encoded on base64
+	 */
+	async updateValue(secretString) {
+
+		try {
+
+			const {
+				versionId,
+				versionStage
+			} = this;
+
+			const params = {
+				SecretId: this.secretName,
+				SecretString: secretString,
+				...versionId && { VersionId: versionId },
+				...versionStage && { VersionStage: versionId }
+			};
+
+			const newValuePromise = await AWS.secretsManager.updateSecret(params);
+
+			this.setInCache(newValuePromise);
+
+			const newValue = await newValuePromise;
+
+			return newValue;
+
+		} catch(error) {
+			throw new AwsSecretsManagerError(error);
+		}
+
+	}
+
+	/**
 	 * Gets the value promise from cache.
 	 *
 	 * @return {Promise} A promise that resolves to the value data, or null if it's not present in cache

--- a/lib/secret-handler.js
+++ b/lib/secret-handler.js
@@ -118,11 +118,13 @@ module.exports = class SecretHandler {
 	/**
 	 * Update the value of the secret.
 	 *
-	 * @param {String} secretString The new value of the secret encoded on base64
+	 * @param {String} secretString The new value of the secret
 	 */
 	async updateValue(secretString) {
 
 		try {
+
+			const encodedSecret = this.parseSecret(secretString);
 
 			const {
 				versionId,
@@ -131,16 +133,14 @@ module.exports = class SecretHandler {
 
 			const params = {
 				SecretId: this.secretName,
-				SecretString: secretString,
+				SecretString: encodedSecret,
 				...versionId && { VersionId: versionId },
 				...versionStage && { VersionStage: versionId }
 			};
 
-			const newValuePromise = await AWS.secretsManager.updateSecret(params);
+			const newValue = await AWS.secretsManager.updateSecret(params);
 
-			this.setInCache(newValuePromise);
-
-			const newValue = await newValuePromise;
+			this.setInCache(newValue);
 
 			return newValue;
 
@@ -157,6 +157,16 @@ module.exports = class SecretHandler {
 	 */
 	getFromCache() {
 		return this.cache.get(this.versionId, this.versionStage);
+	}
+
+	/**
+	 * Parses the secret value to base64 encoded
+	 *
+	 * @param {string} secret The secret to parse
+	 * @return {string} A secret as a base64 encoded string.
+	 */
+	parseSecret(secret) {
+		return Buffer.from(secret).toString('base64');
 	}
 
 };

--- a/lib/secret-handler.js
+++ b/lib/secret-handler.js
@@ -118,13 +118,18 @@ module.exports = class SecretHandler {
 	/**
 	 * Update the value of the secret.
 	 *
-	 * @param {String} secretString The new value of the secret
+	 * @param {object} newSecret The decrypted secret value.
 	 */
-	async updateValue(secretString) {
+	async updateValue(newSecret) {
 
 		try {
 
-			const encodedSecret = this.parseSecret(secretString);
+			const encodedPrivateKey = this.parseKey(newSecret.privateKey);
+
+			const secretString = JSON.stringify({
+				...newSecret,
+				privateKey: encodedPrivateKey
+			});
 
 			const {
 				versionId,
@@ -133,9 +138,9 @@ module.exports = class SecretHandler {
 
 			const params = {
 				SecretId: this.secretName,
-				SecretString: encodedSecret,
+				SecretString: secretString,
 				...versionId && { VersionId: versionId },
-				...versionStage && { VersionStage: versionId }
+				...versionStage && { VersionStage: versionStage }
 			};
 
 			const newValuePromise = AWS.secretsManager.updateSecret(params);
@@ -162,13 +167,13 @@ module.exports = class SecretHandler {
 	}
 
 	/**
-	 * Parses the secret value to base64 encoded
+	 * Parses the key value to base64 encoded
 	 *
-	 * @param {string} secret The secret to parse
-	 * @return {string} A secret as a base64 encoded string.
+	 * @param {string} key The key to parse
+	 * @return {string} A key as a base64 encoded string.
 	 */
-	parseSecret(secret) {
-		return Buffer.from(secret).toString('base64');
+	parseKey(key) {
+		return Buffer.from(key).toString('base64');
 	}
 
 };

--- a/lib/secret-handler.js
+++ b/lib/secret-handler.js
@@ -118,27 +118,28 @@ module.exports = class SecretHandler {
 	/**
 	 * Update the value of the secret.
 	 *
-	 * @param {object} newSecret The decrypted secret value.
+	 * @param {object} newSecret An object with the secret information.
+	 * @return {object} The response of the request to AWS
 	 */
 	async updateValue(newSecret) {
 
 		try {
 
-			const encodedPrivateKey = this.parseKey(newSecret.privateKey);
-
-			const secretString = JSON.stringify({
-				...newSecret,
-				privateKey: encodedPrivateKey
-			});
+			if(!newSecret || !Object.keys(newSecret).length)
+				throw new Error('Secret does not exist or has no content');
 
 			const {
 				versionId,
 				versionStage
 			} = this;
 
+			const currentSecret = await this.getValue(true);
+
+			const secretParam = this.setSecretParam(newSecret, currentSecret);
+
 			const params = {
 				SecretId: this.secretName,
-				SecretString: secretString,
+				...secretParam,
 				...versionId && { VersionId: versionId },
 				...versionStage && { VersionStage: versionStage }
 			};
@@ -158,6 +159,25 @@ module.exports = class SecretHandler {
 	}
 
 	/**
+	 * Returns the object that will be placed as a parameter according to the encoding of the current secret.
+	 *
+	 * @param {object} secret The secret that will be encoded
+	 * @param {object} currentSecret The current secret where the type of secret it contains will be inspected
+	 * @param {String} currentSecret.SecretString The value of the secret in string format
+	 * @return {Promise} A promise that resolves to the value data, or null if it's not present in cache
+	 */
+	setSecretParam(secret, { SecretString }) {
+
+		const serializeSecret = JSON.stringify(secret);
+
+		if(SecretString)
+			return { SecretString: serializeSecret };
+
+		return { SecretBinary: Buffer.from(serializeSecret, 'utf-8').toString('base64') };
+	}
+
+
+	/**
 	 * Gets the value promise from cache.
 	 *
 	 * @return {Promise} A promise that resolves to the value data, or null if it's not present in cache
@@ -165,15 +185,4 @@ module.exports = class SecretHandler {
 	getFromCache() {
 		return this.cache.get(this.versionId, this.versionStage);
 	}
-
-	/**
-	 * Parses the key value to base64 encoded
-	 *
-	 * @param {string} key The key to parse
-	 * @return {string} A key as a base64 encoded string.
-	 */
-	parseKey(key) {
-		return Buffer.from(key).toString('base64');
-	}
-
 };

--- a/lib/secret-handler.js
+++ b/lib/secret-handler.js
@@ -78,7 +78,7 @@ module.exports = class SecretHandler {
 			if(versionStage)
 				params.VersionStage = versionStage;
 
-			const valuePromise = await AWS.secretsManager.getSecretValue(params);
+			const valuePromise = AWS.secretsManager.getSecretValue(params);
 
 			this.setInCache(valuePromise);
 
@@ -138,9 +138,11 @@ module.exports = class SecretHandler {
 				...versionStage && { VersionStage: versionId }
 			};
 
-			const newValue = await AWS.secretsManager.updateSecret(params);
+			const newValuePromise = AWS.secretsManager.updateSecret(params);
 
-			this.setInCache(newValue);
+			this.setInCache(newValuePromise);
+
+			const newValue = await newValuePromise;
 
 			return newValue;
 

--- a/lib/secret-handler.js
+++ b/lib/secret-handler.js
@@ -125,21 +125,28 @@ module.exports = class SecretHandler {
 
 		try {
 
-			if(!newSecret || !Object.keys(newSecret).length)
-				throw new Error('Secret does not exist or has no content');
+			if(!(typeof newSecret === 'object' && !Array.isArray(newSecret)))
+				throw new Error('Secret is not an object');
+
+			if(!Object.keys(newSecret).length)
+				throw new Error('Secret has no content');
 
 			const {
 				versionId,
 				versionStage
 			} = this;
 
-			const currentSecret = await this.getValue(true);
+			const serializeSecret = JSON.stringify(newSecret);
 
-			const secretParam = this.setSecretParam(newSecret, currentSecret);
+			const currentSecret = await this.getValue(true);
 
 			const params = {
 				SecretId: this.secretName,
-				...secretParam,
+				...currentSecret.SecretString ? {
+					SecretString: serializeSecret
+				} : {
+					SecretBinary: Buffer.from(serializeSecret, 'utf-8').toString('base64')
+				},
 				...versionId && { VersionId: versionId },
 				...versionStage && { VersionStage: versionStage }
 			};
@@ -157,25 +164,6 @@ module.exports = class SecretHandler {
 		}
 
 	}
-
-	/**
-	 * Returns the object that will be placed as a parameter according to the encoding of the current secret.
-	 *
-	 * @param {object} secret The secret that will be encoded
-	 * @param {object} currentSecret The current secret where the type of secret it contains will be inspected
-	 * @param {String} currentSecret.SecretString The value of the secret in string format
-	 * @return {Promise} A promise that resolves to the value data, or null if it's not present in cache
-	 */
-	setSecretParam(secret, { SecretString }) {
-
-		const serializeSecret = JSON.stringify(secret);
-
-		if(SecretString)
-			return { SecretString: serializeSecret };
-
-		return { SecretBinary: Buffer.from(serializeSecret, 'utf-8').toString('base64') };
-	}
-
 
 	/**
 	 * Gets the value promise from cache.

--- a/lib/wrappers/aws.js
+++ b/lib/wrappers/aws.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager');
+const { SecretsManagerClient, GetSecretValueCommand, UpdateSecretCommand } = require('@aws-sdk/client-secrets-manager');
 
 const secretsManagerClient = new SecretsManagerClient({});
 
 module.exports.secretsManager = {
 	SecretsManagerClient: secretsManagerClient,
-	getSecretValue: params => secretsManagerClient.send(new GetSecretValueCommand(params))
+	getSecretValue: params => secretsManagerClient.send(new GetSecretValueCommand(params)),
+	updateSecret: params => secretsManagerClient.send(new UpdateSecretCommand(params))
 };

--- a/tests/secret-handler.js
+++ b/tests/secret-handler.js
@@ -158,9 +158,19 @@ describe('Secret Handler', () => {
 			assert.deepStrictEqual(this.secretsManagerClientMock.commandCalls(UpdateSecretCommand, paramsUpdateWithSecretString).length, 1);
 		});
 
-		it('Should reject if it fails to parse the secret', async () => {
+		it('Should reject if secret is not an object', async () => {
 
 			await assert.rejects(() => secretHandler.updateValue(), {
+				name: 'AwsSecretsManagerError'
+			});
+
+			assert.deepStrictEqual(this.secretsManagerClientMock.commandCalls(GetSecretValueCommand).length, 0);
+			assert.deepStrictEqual(this.secretsManagerClientMock.commandCalls(UpdateSecretCommand).length, 0);
+		});
+
+		it('Should reject if secret has no content', async () => {
+
+			await assert.rejects(() => secretHandler.updateValue({}), {
 				name: 'AwsSecretsManagerError'
 			});
 


### PR DESCRIPTION
[Tarea](https://janiscommerce.atlassian.net/browse/JSS-5) / [Subtarea](https://janiscommerce.atlassian.net/browse/JSS-12)

### Descripción:
Se deberá agregar un nuevo metodo ([UpdateSecret](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SecretsManager.html#updateSecret-property)) al package de  (el metodo se debera llamar updateValue para tener concordancia con el getValue)

### Solución: 
- Agregué el método updateValue() que recibe el string en base64. para actualizar el secret mediante el método updateSecret() de AWS. Después setea en el caché los nuevos valores de VersionId y VersionStage recibidos.
- Agregué en el wrapper el método updateSecret para su fácil uso.
- Añadidos los tests correspondientes